### PR TITLE
Add support for passing a dictionary for zstd compression and decompression

### DIFF
--- a/kompressor-zstd--nativelib/src/commonMain/kotlin/com/ensody/kompressor/zstd/Zstd.kt
+++ b/kompressor-zstd--nativelib/src/commonMain/kotlin/com/ensody/kompressor/zstd/Zstd.kt
@@ -3,7 +3,7 @@ package com.ensody.kompressor.zstd
 import com.ensody.kompressor.core.AsyncSliceTransform
 
 /** Creates a zstd compression transformation. */
-public expect fun AsyncZstdCompressor(compressionLevel: Int = 3): AsyncSliceTransform
+public expect fun AsyncZstdCompressor(compressionLevel: Int = 3, dictionary: ByteArray? = null): AsyncSliceTransform
 
 /** Creates a zstd decompression transformation. */
-public expect fun AsyncZstdDecompressor(): AsyncSliceTransform
+public expect fun AsyncZstdDecompressor(dictionary: ByteArray? = null): AsyncSliceTransform

--- a/kompressor-zstd--nativelib/src/commonTest/kotlin/com/ensody/kompressor/zstd/ZstdTest.kt
+++ b/kompressor-zstd--nativelib/src/commonTest/kotlin/com/ensody/kompressor/zstd/ZstdTest.kt
@@ -47,6 +47,15 @@ internal class ZstdTest {
     }
 
     @Test
+    fun dictionaryRoundtrip() {
+        val dictionary = "this is a test dictionary".encodeToByteArray()
+        val data = "this is some data to compress using a dictionary".encodeToByteArray()
+        val compressed = ZstdCompressor(dictionary = dictionary).transform(data)
+        val decompressed = ZstdDecompressor(dictionary = dictionary).transform(compressed)
+        assertContentEquals(data, decompressed)
+    }
+
+    @Test
     fun largeSample() {
         val seed = 42
         val size: Long = 256L * 1024 * 1024 + 3

--- a/kompressor-zstd--nativelib/src/commonTest/kotlin/com/ensody/kompressor/zstd/ZstdTest.kt
+++ b/kompressor-zstd--nativelib/src/commonTest/kotlin/com/ensody/kompressor/zstd/ZstdTest.kt
@@ -53,6 +53,15 @@ internal class ZstdTest {
         val compressed = ZstdCompressor(dictionary = dictionary).transform(data)
         val decompressed = ZstdDecompressor(dictionary = dictionary).transform(compressed)
         assertContentEquals(data, decompressed)
+
+        // Verify dictionary is actually used: decompression should fail without dictionary
+        kotlin.test.assertFails {
+            ZstdDecompressor().transform(compressed)
+        }
+
+        // Verify dictionary is actually effective: it should be smaller than without dictionary
+        val compressedWithoutDict = ZstdCompressor().transform(data)
+        kotlin.test.assertTrue(compressed.size < compressedWithoutDict.size, "Compressed with dict should be smaller")
     }
 
     @Test

--- a/kompressor-zstd--nativelib/src/jvmCommonMain/jni/Wrapper.cpp
+++ b/kompressor-zstd--nativelib/src/jvmCommonMain/jni/Wrapper.cpp
@@ -39,6 +39,40 @@ Java_com_ensody_kompressor_zstd_ZstdWrapper_setParameter(
 }
 
 JNIEXPORT jlong JNICALL
+Java_com_ensody_kompressor_zstd_ZstdWrapper_loadCompressorDictionary(
+        JNIEnv *env,
+        jobject type,
+        jlong cctxPointer,
+        jbyteArray dictionary
+) {
+    auto cctx = reinterpret_cast<ZSTD_CCtx *>(cctxPointer);
+    auto dictionaryElements = env->GetByteArrayElements(dictionary, NULL);
+    if (dictionaryElements == NULL) {
+        return -ZSTD_error_GENERIC;
+    }
+    size_t result = ZSTD_CCtx_loadDictionary(cctx, dictionaryElements, env->GetArrayLength(dictionary));
+    env->ReleaseByteArrayElements(dictionary, dictionaryElements, JNI_ABORT);
+    return result;
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_ensody_kompressor_zstd_ZstdWrapper_loadDecompressorDictionary(
+        JNIEnv *env,
+        jobject type,
+        jlong dctxPointer,
+        jbyteArray dictionary
+) {
+    auto dctx = reinterpret_cast<ZSTD_DCtx *>(dctxPointer);
+    auto dictionaryElements = env->GetByteArrayElements(dictionary, NULL);
+    if (dictionaryElements == NULL) {
+        return -ZSTD_error_GENERIC;
+    }
+    size_t result = ZSTD_DCtx_loadDictionary(dctx, dictionaryElements, env->GetArrayLength(dictionary));
+    env->ReleaseByteArrayElements(dictionary, dictionaryElements, JNI_ABORT);
+    return result;
+}
+
+JNIEXPORT jlong JNICALL
 Java_com_ensody_kompressor_zstd_ZstdWrapper_compressStream(
         JNIEnv *env,
         jobject type,

--- a/kompressor-zstd--nativelib/src/jvmCommonMain/kotlin/com/ensody/kompressor/zstd/ZstdWrapper.kt
+++ b/kompressor-zstd--nativelib/src/jvmCommonMain/kotlin/com/ensody/kompressor/zstd/ZstdWrapper.kt
@@ -29,6 +29,9 @@ internal object ZstdWrapper : NativeBuildsJvmLib {
 
     external fun setParameter(cctx: Long, parameter: Int, value: Int): Long
 
+    external fun loadCompressorDictionary(cctx: Long, dictionary: ByteArray): Long
+    external fun loadDecompressorDictionary(dctx: Long, dictionary: ByteArray): Long
+
     external fun compressStream(
         cctx: Long,
         input: ByteArraySlice,

--- a/kompressor-zstd--nativelib/src/nonJsMain/kotlin/com/ensody/kompressor/zstd/Zstd.nonjs.kt
+++ b/kompressor-zstd--nativelib/src/nonJsMain/kotlin/com/ensody/kompressor/zstd/Zstd.nonjs.kt
@@ -5,13 +5,13 @@ import com.ensody.kompressor.core.SliceTransform
 import com.ensody.kompressor.core.toAsync
 
 /** Creates a zstd compression transformation. */
-public expect fun ZstdCompressor(compressionLevel: Int = 3): SliceTransform
+public expect fun ZstdCompressor(compressionLevel: Int = 3, dictionary: ByteArray? = null): SliceTransform
 
 /** Creates a zstd decompression transformation. */
-public expect fun ZstdDecompressor(): SliceTransform
+public expect fun ZstdDecompressor(dictionary: ByteArray? = null): SliceTransform
 
-public actual fun AsyncZstdCompressor(compressionLevel: Int): AsyncSliceTransform =
-    ZstdCompressor(compressionLevel = compressionLevel).toAsync()
+public actual fun AsyncZstdCompressor(compressionLevel: Int, dictionary: ByteArray?): AsyncSliceTransform =
+    ZstdCompressor(compressionLevel = compressionLevel, dictionary = dictionary).toAsync()
 
-public actual fun AsyncZstdDecompressor(): AsyncSliceTransform =
-    ZstdDecompressor().toAsync()
+public actual fun AsyncZstdDecompressor(dictionary: ByteArray?): AsyncSliceTransform =
+    ZstdDecompressor(dictionary = dictionary).toAsync()


### PR DESCRIPTION
Add support for an optional dictionary parameter to improve the speed and ratio of compression and decompression when you already know something about the data.

Introduction to dictionary use case:
https://github.com/facebook/zstd?tab=readme-ov-file#the-case-for-small-data-compression

Wider look:
https://httptoolkit.com/blog/dictionary-compression-performance-zstd-brotli/